### PR TITLE
Set default shell to bash for linux build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ permissions:
 jobs:
   linux:
     name: debian trixie (${{ matrix.name }})
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Motivation
- The CI used `/bin/sh` for `run` steps which caused failures when bash-specific syntax (`[[ ... ]]`, `${VAR::7}`) was used in the job, so the job should run `run` steps with `bash` by default.

### Description
- Add `defaults.run.shell: bash` to the `linux` job in `.github/workflows/build.yml` so all `run` steps in that job execute with `bash`.

### Testing
- Verified the patch content with `git diff -- .github/workflows/build.yml` and committed the change successfully with `git commit` (succeeded).
- Attempted a YAML parse check using `python` + `yaml.safe_load(...)`, but it failed because `PyYAML` is not installed in the environment (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4556b218c8328b9a0c285a7cf2f94)