### PR TITLE
Fix Debian CI changelog versioning for non-tag builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,12 +33,21 @@ jobs:
       - name: Compute package version
         run: |
           set -euo pipefail
+          base_version="$(dpkg-parsechangelog -S Version)"
+          if [[ "${base_version}" == *-* ]]; then
+            base_upstream="${base_version%-*}"
+            base_revision="${base_version##*-}"
+          else
+            base_upstream="${base_version}"
+            base_revision="1"
+          fi
+
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             echo "ARTIFACT_TAG=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
             echo "DEB_VERSION=${GITHUB_REF_NAME#v}-1" >> "$GITHUB_ENV"
           else
             echo "ARTIFACT_TAG=sha-${GITHUB_SHA::7}" >> "$GITHUB_ENV"
-            echo "DEB_VERSION=0.0.0+sha${GITHUB_SHA::7}-1" >> "$GITHUB_ENV"
+            echo "DEB_VERSION=${base_upstream}+sha${GITHUB_SHA::7}-${base_revision}" >> "$GITHUB_ENV"
           fi
           echo "DEB_ARCH=$(dpkg --print-architecture)" >> "$GITHUB_ENV"
 
@@ -48,7 +57,7 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends \
             build-essential fakeroot dpkg-dev devscripts debhelper \
-            libevdev-dev libinput-dev ca-certificates
+            libevdev-dev libinput-dev ca-certificates libdistro-info-perl
 
       - name: Patch changelog version for CI artifact
         run: |


### PR DESCRIPTION
### Motivation
- Non-tag CI builds were generating `DEB_VERSION=0.0.0+sha...-1`, which can be lower than the current `debian/changelog` version and causes `dch --newversion` to fail.

### Description
- Use `dpkg-parsechangelog -S Version` to derive the current package base version and split it into upstream and revision parts.
- For non-tag builds generate `DEB_VERSION` as `<base_upstream>+sha<shortsha>-<base_revision>` so the CI version is greater than or equal to the changelog version and `dch` accepts it.
- Install `libdistro-info-perl` in the build container to suppress distro-name warnings from `dch`.
- Implement these changes in `.github/workflows/build.yml` (compute logic and dependency list).

### Testing
- Applied the patch to `.github/workflows/build.yml` and the file update completed successfully (automated patch application).
- Verified the diff of `.github/workflows/build.yml` shows the intended changes using `git diff` (succeeded).
- Executed the version-generation shell snippet with a sample `GITHUB_REF` and `GITHUB_SHA` and confirmed it produces `1.0.0.4+sha02b2c61-1` for branch builds (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4673e42dc8328898a7449a504c23a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved version computation and management in the build pipeline with refined handling of upstream and revision components.
  * Enhanced build infrastructure to support more robust package version formatting.
  * Updated build dependencies to support improved package generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->