### PR TITLE
Fix CI build by installing dpkg tooling before version computation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install build dependencies
+        run: |
+          set -euo pipefail
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential fakeroot dpkg-dev devscripts debhelper \
+            libevdev-dev libinput-dev ca-certificates libdistro-info-perl
+
       - name: Compute package version
         run: |
           set -euo pipefail
@@ -50,14 +58,6 @@ jobs:
             echo "DEB_VERSION=${base_upstream}+sha${GITHUB_SHA::7}-${base_revision}" >> "$GITHUB_ENV"
           fi
           echo "DEB_ARCH=$(dpkg --print-architecture)" >> "$GITHUB_ENV"
-
-      - name: Install build dependencies
-        run: |
-          set -euo pipefail
-          apt-get update
-          apt-get install -y --no-install-recommends \
-            build-essential fakeroot dpkg-dev devscripts debhelper \
-            libevdev-dev libinput-dev ca-certificates libdistro-info-perl
 
       - name: Patch changelog version for CI artifact
         run: |


### PR DESCRIPTION
### Motivation
- The workflow computed `DEB_VERSION` using `dpkg-parsechangelog` before installing `dpkg-dev`/`devscripts`, which caused `dpkg-parsechangelog: command not found` in the Debian container job.

### Description
- Move the `Install build dependencies` step before the `Compute package version` step in `/.github/workflows/build.yml` so `dpkg-parsechangelog` and other dpkg tooling are available; the existing version/tag logic (`ARTIFACT_TAG`, `DEB_VERSION`) remains unchanged.

### Testing
- Verified the change by inspecting the workflow diff with `git diff .github/workflows/build.yml` and by viewing the updated file with `nl -ba .github/workflows/build.yml | sed -n '20,90p'`, confirming the step ordering was updated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b46b6dcdc48328bd6f36575679bbb6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD build pipeline by reorganizing dependency installation steps to execute earlier in the build process and eliminating redundant installation commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->