### PR TITLE
Handle --help without entering daemon loop

### DIFF
--- a/rce.c
+++ b/rce.c
@@ -118,7 +118,19 @@ int find_evdev(struct libevdev **devices) {
     return device_num;
 }
 
-int main() {
+int main(int argc, char **argv) {
+    if (argc > 1) {
+        if (strcmp(argv[1], "--help") == 0 || strcmp(argv[1], "-h") == 0) {
+            printf("Usage: %s [--help]\n", argv[0]);
+            printf("Runs evdev right-click emulation daemon.\n");
+            return 0;
+        }
+
+        fprintf(stderr, "Unknown option: %s\n", argv[1]);
+        fprintf(stderr, "Try '%s --help' for usage.\n", argv[0]);
+        return 1;
+    }
+
     while (1) {
         // Try to read some configurable options from env
         char *env = NULL;


### PR DESCRIPTION
### Motivation
- The CI smoke-test invokes `./out/evdev-rce --help` but the binary previously ignored arguments and immediately entered the daemon loop, causing repeated `find_evdev()` errors in container logs.

### Description
- Change `main` signature to `int main(int argc, char **argv)` and add explicit handling for `--help` and `-h` that prints usage and exits with `0`.
- Add handling for unknown options that prints an error message and exits with non-zero status.
- Modified file: `rce.c`.

### Testing
- Ran `make clean && make`, which failed in this environment due to missing development headers for `libevdev` (`libevdev/libevdev-uinput.h`), so a local binary could not be produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b48f2a4bdc83289953c70a81acaa8c)