### PR TITLE
docs: add instructions for installing from GitHub APT repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,25 @@ LONG_CLICK_INTERVAL=500 LONG_CLICK_FUZZ=50 evdev-rce
 ```
 
 To customize those options.
+
+Install from GitHub APT repository
+---
+
+This repository's GitHub Actions `build.yml` workflow publishes a flat Debian APT repository to the GitHub release tag `apt` whenever a version tag (`v*`) is built.
+
+To install from that repository:
+
+```bash
+sudo mkdir -p /etc/apt/sources.list.d
+cat <<'EOF' | sudo tee /etc/apt/sources.list.d/evdev-rce-github.list
+deb [trusted=yes] https://github.com/bareboat-necessities/evdev-right-click-emulation/releases/download/apt/ ./
+EOF
+
+sudo apt-get update
+sudo apt-get install evdev-rce
+```
+
+Notes:
+
+- The repository is currently published as an unsigned flat repository, so the example uses `trusted=yes`.
+- Packages are published to the `apt` release tag and include the generated `Packages`, `Packages.gz`, and `Release` metadata files alongside `.deb` artifacts.


### PR DESCRIPTION
### Motivation
- Ensure users can install published Debian packages by documenting the repository that the existing GitHub Actions workflow publishes and how to use it.

### Description
- Added an "Install from GitHub APT repository" section to `README.md` with commands to add the release-backed flat APT repo, update, and install `evdev-rce`; noted the repo is unsigned and uses `trusted=yes` in the example.
- Verified the existing `.github/workflows/build.yml` already builds a flat Debian APT repository (`Packages`, `Packages.gz`, `Release`) and uploads it to the versioned release and the `apt` release tag, so no workflow changes were required.

### Testing
- No automated tests were applicable for this documentation-only change; repository and workflow files were inspected and the README update was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4acf3ee3c8328ab10ff3d0e1b8800)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive installation instructions for setting up packages from a GitHub APT repository, including repository configuration steps and package installation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->